### PR TITLE
Add support for Laravel 13 and PHP 8.5

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.5'
           coverage: none
 
       - name: Install composer dependencies

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,8 +13,8 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, macos-latest]
-        php: [8.2, 8.3, 8.4]
-        laravel: [^11.38, 12.*]
+        php: [8.2, 8.3, 8.4, 8.5]
+        laravel: [^11.38, 12.*, 13.*]
         stability: [prefer-lowest, prefer-stable]
         include:
           - laravel: ^11.38
@@ -23,6 +23,14 @@ jobs:
           - laravel: 12.*
             testbench: 10.*
             carbon: ^2.63|^3.0
+          - laravel: 13.*
+            testbench: 11.*
+            carbon: ^3.0
+        exclude:
+          - laravel: 13.*
+            php: 8.2
+          - laravel: ^11.38
+            php: 8.5
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -17,17 +17,17 @@
     ],
     "require": {
         "php": "^8.2",
-        "illuminate/contracts": "^11.0|^12.0",
+        "illuminate/contracts": "^11.0|^12.0|^13.0",
         "spatie/laravel-package-tools": "^1.14.0"
     },
     "require-dev": {
         "larastan/larastan": "^3.1",
         "laravel/pint": "^1.13",
         "nunomaduro/collision": "^8.0",
-        "orchestra/testbench": "^9.0|^10.0",
-        "pestphp/pest": "^3.0",
-        "pestphp/pest-plugin-arch": "^3.0",
-        "pestphp/pest-plugin-laravel": "^3.0",
+        "orchestra/testbench": "^9.0|^10.0|^11.0",
+        "pestphp/pest": "^3.0|^4.0",
+        "pestphp/pest-plugin-arch": "^3.0|^4.0",
+        "pestphp/pest-plugin-laravel": "^3.0|^4.0",
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan-deprecation-rules": "^2.0",
         "phpstan/phpstan-phpunit": "^2.0"

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -9,5 +9,4 @@ parameters:
     tmpDir: build/phpstan
     checkOctaneCompatibility: true
     checkModelProperties: true
-    checkMissingIterableValueType: false
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.2/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
     backupGlobals="false"
     bootstrap="vendor/autoload.php"
     colors="true"
@@ -20,13 +20,6 @@
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <coverage>
-        <report>
-            <html outputDirectory="build/coverage"/>
-            <text outputFile="build/coverage.txt"/>
-            <clover outputFile="build/logs/clover.xml"/>
-        </report>
-    </coverage>
     <logging>
         <junit outputFile="build/report.junit.xml"/>
     </logging>

--- a/src/Finders/LanguageFileFinder.php
+++ b/src/Finders/LanguageFileFinder.php
@@ -37,6 +37,6 @@ readonly class LanguageFileFinder implements LanguageFileFinderContract
             });
         }
 
-        return new Collection();
+        return new Collection;
     }
 }

--- a/src/Finders/LanguageNamespaceFinder.php
+++ b/src/Finders/LanguageNamespaceFinder.php
@@ -12,7 +12,7 @@ readonly class LanguageNamespaceFinder implements LanguageNamespaceFinderContrac
 
     public function execute(): Collection
     {
-        $namespacesCollection = new Collection();
+        $namespacesCollection = new Collection;
 
         // Get Translator namespaces
         $loader = $this->translator->getLoader();


### PR DESCRIPTION
## Summary

- Add Laravel 13 support: `illuminate/contracts` now allows `^13.0`, `orchestra/testbench` allows `^11.0`
- Allow Pest 4 (`^3.0|^4.0`) — Pest 3 stays in range since Pest 4 requires PHP 8.3+ and the package still supports PHP 8.2 with Laravel 11
- Add PHP 8.5 and Laravel 13 to the test matrix, excluding Laravel 13 + PHP 8.2 (framework requires ^8.3) and Laravel 11 + PHP 8.5 (never officially supported)
- Run the PHPStan workflow on PHP 8.5

## Fixes required along the way

- **phpunit.xml.dist**: removed the coverage report config — PHPUnit 12 (Pest 4) aborts the run when coverage reports are configured but no coverage driver is loaded. `composer test-coverage` still works via the `--coverage` flag.
- **phpstan.neon.dist**: dropped `checkMissingIterableValueType`, removed in PHPStan 2 (config failed to parse).
- Pint style fixes in two finder classes required by newer rules.

## Testing

- 6 tests / 84 assertions pass on Laravel 13.20 + Pest 4.7.5 + PHP 8.5; PHPStan and Pint clean
- Simulated the riskiest new CI cells locally on PHP 8.5: Laravel 13 `--prefer-lowest` (framework 13.12, pest 4.4.1) and Laravel 12 `--prefer-lowest` (framework 12.61, pest 3.8.5) — both pass